### PR TITLE
chore: updated lmr reduction factor

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -265,7 +265,7 @@ namespace elixir::search
             } else {
                 int R = 1;
                 if (move.is_quiet() && depth >= 3 && legals > 1 + (pv_node ? 1 : 0)) {
-                    R = lmr[depth][legals];
+                    R = lmr[depth][legals] + (pv_node ? 0 : 1);
                 }
                 score = -negamax(board, -alpha - 1, -alpha, depth - R, info, local_pv, ss + 1);
                 if (score > alpha && (score < beta || R > 1)) {


### PR DESCRIPTION
Bench: 907355

Elo   | 6.40 +- 4.51 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9234 W: 1959 L: 1789 D: 5486
Penta | [153, 1076, 2025, 1174, 189]
http://basandraiarjun.pythonanywhere.com/test/34/