### PR TITLE
feat: added butterfly history heuristic

### DIFF
--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -122,8 +122,8 @@ namespace elixir {
         hash_key = 0ULL;
         eval = 0;
         phase_score = 0;
-        for (int i = 0; i < 12; i++) {
-            for (int j = 0; j < MAX_DEPTH; j++) {
+        for (int i = 0; i < 64; i++) {
+            for (int j = 0; j < 64; j++) {
                 history[i][j] = 0;
             }
         }

--- a/src/board/board.h
+++ b/src/board/board.h
@@ -158,13 +158,15 @@ namespace elixir {
         void make_null_move();
         void unmake_null_move();
 
-        inline void update_history(Piece piece, Square to, int depth) {
-            history[static_cast<int>(piece)][static_cast<int>(to)] += depth;
+        inline void update_history(Square from, Square to, int depth) {
+            history[static_cast<int>(from)][static_cast<int>(to)] += depth;
+            int hist_max = 1024;
+            history[static_cast<int>(from)][static_cast<int>(to)] = std::min(history[static_cast<int>(from)][static_cast<int>(to)], hist_max);
         }
 
         bool parse_uci_move(std::string move);
 
-        int history[12][MAX_DEPTH]{};
+        int history[64][64]{};
     private:
         std::array<Bitboard, 2> b_occupancies{};
         std::array<Bitboard, 6> b_pieces{};

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -43,7 +43,7 @@ namespace elixir {
             else if (move.is_castling()) { value += 256; }
 
             // (~30 ELO)
-            value += board.history[static_cast<int>(move.get_piece())][static_cast<int>(to)];
+            value += board.history[static_cast<int>(from)][static_cast<int>(to)];
 
             scores[i] = value;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -223,7 +223,7 @@ namespace elixir::search
                                 ss->killers[1] = ss->killers[0];
                                 ss->killers[0] = best_move;
                             }
-                            board.update_history(move.get_piece(), move.get_to(), depth);
+                            board.update_history(move.get_from(), move.get_to(), depth);
                         }
                         flag = TT_BETA;
                         break;


### PR DESCRIPTION
Bench: 680261

Elo   | 12.91 +- 6.86 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3770 W: 792 L: 652 D: 2326
Penta | [45, 404, 869, 500, 67]
https://basandraiarjun.pythonanywhere.com/test/48/