### PR TITLE
feat: updated butterfly history formula to squared formula

### DIFF
--- a/src/board/board.h
+++ b/src/board/board.h
@@ -159,7 +159,7 @@ namespace elixir {
         void unmake_null_move();
 
         inline void update_history(Square from, Square to, int depth) {
-            history[static_cast<int>(from)][static_cast<int>(to)] += depth;
+            history[static_cast<int>(from)][static_cast<int>(to)] += depth * depth;
             int hist_max = 1024;
             history[static_cast<int>(from)][static_cast<int>(to)] = std::min(history[static_cast<int>(from)][static_cast<int>(to)], hist_max);
         }


### PR DESCRIPTION
Bench: 675389

Elo   | 4.38 +- 3.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15294 W: 3059 L: 2866 D: 9369
Penta | [260, 1708, 3534, 1869, 276]
https://basandraiarjun.pythonanywhere.com/test/58/