### PR TITLE
feat: added SEE move ordering

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -49,7 +49,7 @@ namespace elixir {
             } else if (move.is_capture() || move.is_en_passant()) {
                 auto captured_piece = move.is_en_passant() ? static_cast<int>(PieceType::PAWN) : static_cast<int>(board.piece_to_piecetype(board.piece_on(to)));
                 value = eval::piece_values[captured_piece];
-                value += 1000000000;
+                value += search::SEE(board, move, -107) ? 1000000000 : -1000000;
             } else if (move == ss->killers[0]) { 
                 value = 800000000; 
             } else if (move == ss->killers[1]) { 


### PR DESCRIPTION
Bench: 1855006

Elo   | 30.74 +- 12.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.63 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1632 W: 508 L: 364 D: 760
Penta | [51, 139, 317, 233, 76]
https://chess.aronpetkovski.com/test/323/