### PR TITLE
feat: added qsearch see pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -87,6 +87,8 @@ namespace elixir::search {
 
         while ((move = mp.next_move()) != move::NO_MOVE) {
 
+            if (!SEE(board, move, -7)) continue;
+
             if (!board.make_move(move)) continue; 
 
             legals++;
@@ -257,12 +259,12 @@ namespace elixir::search {
             */
             if (skip_quiets && is_quiet_move) continue;
 
-            /*
-            | Late Move Pruning [LMP] (~30 ELO) : Skip late quiet moves if  |
-            | we've already searched the most promising moves because they  |
-            | are likely to be bad.                                         |  
-            */
             if (!root_node && best_score > -MATE_FOUND) {
+                /*
+                | Late Move Pruning [LMP] (~30 ELO) : Skip late quiet moves if  |
+                | we've already searched the most promising moves because they  |
+                | are likely to be bad.                                         |  
+                */
                 if (is_quiet_move && legals >= LMP_BASE + LMP_MULTIPLIER * depth * depth) {
                     skip_quiets = true;
                 }


### PR DESCRIPTION
Bench: 1195620

Elo   | 54.76 +- 15.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 998 W: 348 L: 192 D: 458
Penta | [15, 88, 184, 150, 62]
https://chess.aronpetkovski.com/test/330/