### PR TITLE
Time Management

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -526,9 +526,6 @@ namespace elixir::search {
             while (1) {
                 score = negamax(board, alpha, beta, current_depth, info, pv, ss);
 
-                if (should_stop(info)) break;
-                if (info.stopped) break;
-
                 if (score > alpha && score < beta) break;
 
                 if (score <= alpha) {
@@ -541,13 +538,13 @@ namespace elixir::search {
                 }
 
                 delta *= ASP_MULTIPLIER;
+
+                if (should_stop(info)) break;
+                if (info.stopped) break;
             }
 
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-
-            if (should_stop_early(info)) break;
-            if (info.stopped) break;
 
             if (print_info) {
                 int time_ms = duration.count();
@@ -566,6 +563,9 @@ namespace elixir::search {
                 pv.print_pv();
                 std::cout << std::endl;
             }
+
+            if (should_stop_early(info)) break;
+            if (info.stopped) break;
         }
 
         if (print_info) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -86,6 +86,7 @@ namespace elixir::search {
         pv.length = 0;
 
         if (should_stop(info)) return 0;
+        if (info.stopped) return 0;
 
         if (ss->ply > info.seldepth) info.seldepth = ss->ply;
 
@@ -166,6 +167,9 @@ namespace elixir::search {
         bool in_check = board.is_in_check();
         int eval;
 
+        if (should_stop(info)) return 0;
+        if (info.stopped) return 0;
+
         if (ss->ply > info.seldepth) info.seldepth = ss->ply;
         
         /*
@@ -178,7 +182,6 @@ namespace elixir::search {
         */
         if (depth <= 0) return qsearch(board, alpha, beta, info, pv, ss);
 
-        if (should_stop(info)) return 0;
 
         if (!root_node) {
             /*
@@ -523,7 +526,8 @@ namespace elixir::search {
             while (1) {
                 score = negamax(board, alpha, beta, current_depth, info, pv, ss);
 
-                if (should_stop(info) || info.stopped) break;
+                if (should_stop(info)) break;
+                if (info.stopped) break;
 
                 if (score > alpha && score < beta) break;
 
@@ -543,7 +547,6 @@ namespace elixir::search {
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
             if (should_stop_early(info)) break;
-
             if (info.stopped) break;
 
             if (print_info) {

--- a/src/search.h
+++ b/src/search.h
@@ -28,15 +28,17 @@ namespace elixir::search
           start_time(std::chrono::high_resolution_clock::now()),
           depth(depth),
           seldepth(0),
-          time_left(0) {}
-        SearchInfo(int depth, std::chrono::high_resolution_clock::time_point start_time, double time_left)
+          soft_limit(0),
+          hard_limit(0) {}
+        SearchInfo(int depth, std::chrono::high_resolution_clock::time_point start_time, F64 soft_limit, F64 hard_limit)
         : nodes(0),
           depth(depth),
           seldepth(0),
           stopped(false),
           timed(true),
           start_time(start_time),
-          time_left(time_left) {}
+          soft_limit(soft_limit),
+          hard_limit(hard_limit) {}
 
         ~SearchInfo() = default;
         unsigned long long nodes;
@@ -45,7 +47,8 @@ namespace elixir::search
         bool stopped;
         bool timed;
         std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
-        F64 time_left;
+        F64 soft_limit;
+        F64 hard_limit;
     };
 
     struct PVariation

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -9,7 +9,7 @@
 
 namespace elixir {
     int DEFAULT_MOVESTOGO = -1;
-    int DEFAULT_MOVE_OVERHEAD = 48;
+    int DEFAULT_MOVE_OVERHEAD = 100;
     int INCREMENT_SCALE = 1;
 }
 

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -8,7 +8,7 @@
 #endif
 
 namespace elixir {
-    int DEFAULT_MOVESTOGO = 19;
+    int DEFAULT_MOVESTOGO = -1;
     int DEFAULT_MOVE_OVERHEAD = 48;
     int INCREMENT_SCALE = 1;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -26,19 +26,19 @@ namespace elixir::uci {
         if (time < 0) time = 1000;
 
         const int overhead = std::min<int>(DEFAULT_MOVE_OVERHEAD, time / 2);
-        time -= overhead;
+        time -= DEFAULT_MOVE_OVERHEAD;
 
         double base_time;
 
         if (movestogo != -1) {
             base_time = time / movestogo;
         } else {
-            base_time = time * 0.054 + inc * 0.85;            
+            base_time = time * 0.054 + inc * 0.6;            
         }
         const auto max_bound = 0.76 * time;
 
         const auto soft_bound = std::min(0.76 * base_time, max_bound);
-        const auto hard_bound = std::min(3.04 * base_time, max_bound);
+        const auto hard_bound = std::min(2.50 * base_time, max_bound);
 
         info = search::SearchInfo(MAX_DEPTH, start_time, soft_bound, hard_bound);
     }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -22,6 +22,27 @@
 
 namespace elixir::uci {
 
+    void optimum_time(search::SearchInfo &info, F64 time, F64 inc, int movestogo, std::chrono::high_resolution_clock::time_point start_time) {
+        if (time < 0) time = 1000;
+
+        const int overhead = std::min<int>(DEFAULT_MOVE_OVERHEAD, time / 2);
+        time -= overhead;
+
+        double base_time;
+
+        if (movestogo != -1) {
+            base_time = time / movestogo;
+        } else {
+            base_time = time * 0.054 + inc * 0.85;            
+        }
+        const auto max_bound = 0.76 * time;
+
+        const auto soft_bound = std::min(0.76 * base_time, max_bound);
+        const auto hard_bound = std::min(3.04 * base_time, max_bound);
+
+        info = search::SearchInfo(MAX_DEPTH, start_time, soft_bound, hard_bound);
+    }
+
     void parse_position(std::string input, Board &board) {
         if (input.substr(9, 8) == "startpos") {
             board.from_fen(start_position);
@@ -58,7 +79,7 @@ namespace elixir::uci {
         std::vector<std::string> tokens = str_utils::split(input, ' ');
         search::SearchInfo info;
         const auto start_time = std::chrono::high_resolution_clock::now();
-        int depth = MAX_DEPTH, movestogo = DEFAULT_MOVESTOGO;
+        int depth = MAX_DEPTH, movestogo = -1;
         F64 time = 0, inc = 0;
         // If there are no tokens after "go" command, return
         if (tokens.size() <= 1) return;
@@ -92,9 +113,7 @@ namespace elixir::uci {
         }
 
         if (time != 0) {
-            const F64 limit = std::max(0.001, time - DEFAULT_MOVE_OVERHEAD);
-            const F64 search_time = (limit / static_cast<F64>(movestogo) + inc / INCREMENT_SCALE);
-            info = search::SearchInfo(depth, start_time, search_time);
+            optimum_time(info, time, inc, movestogo, start_time);
         }
         else {
             info = search::SearchInfo(depth);


### PR DESCRIPTION
Bench: 721354

STC (10+0.1s) :
Elo   | 30.53 +- 16.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.11 (-2.94, 2.94) [0.00, 10.00]
Games | N: 890 W: 269 L: 191 D: 430
Penta | [8, 96, 184, 124, 33]
https://chess.aronpetkovski.com/test/479/

LTC (60+0.6s) :
Elo   | 41.74 +- 18.87 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 644 W: 196 L: 119 D: 329
Penta | [8, 64, 119, 105, 26]
https://chess.aronpetkovski.com/test/481/