### PR TITLE
feat: use two-fold repetition rule instead of 3-fold

### DIFF
--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -564,7 +564,7 @@ namespace elixir {
 
     bool Board::is_repetition() const {
         const auto limit = std::max<int>(0, undo_stack.size() - fifty_move_counter - 2);
-        int counter = 2;
+        int counter = 1;
         for (int i = undo_stack.size() - 4; i >= limit; i -= 2) {
             if (undo_stack[i].hash_key == hash_key) {
                 if (--counter == 0) {


### PR DESCRIPTION
Bench: 719099

Elo   | 14.28 +- 7.61 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3896 W: 1029 L: 869 D: 1998
Penta | [104, 408, 773, 550, 113]
https://chess.aronpetkovski.com/test/486/