### PR TITLE
Introduce counter moves for move ordering

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -12,6 +12,12 @@ namespace elixir {
                 history[i][j] = 0;
             }
         }
+        for (int i = 0; i < 64; i++) {
+            for (int j = 0; j < 64; j++) {
+                counter_moves[0][i][j] = move::NO_MOVE;
+                counter_moves[1][i][j] = move::NO_MOVE;
+            }
+        }
     }
 
     int History::scale_bonus(int score, int bonus) {
@@ -37,4 +43,13 @@ namespace elixir {
     int History::get_history(Square from, Square to) const {
         return history[static_cast<int>(from)][static_cast<int>(to)];
     }
+
+    void History::update_countermove(Color side, Square from, Square to, move::Move countermove) {
+        counter_moves[static_cast<int>(side)][static_cast<int>(from)][static_cast<int>(to)] = countermove;
+    }
+
+    move::Move History::get_countermove(Color side, Square from, Square to) const {
+        return counter_moves[static_cast<int>(side)][static_cast<int>(from)][static_cast<int>(to)];
+    }
+
 }

--- a/src/history.h
+++ b/src/history.h
@@ -15,8 +15,12 @@ namespace elixir {
         void update_history(Square from, Square to, int depth, MoveList &bad_quiets);
         int get_history(Square from, Square to) const;
 
+        void update_countermove(Color side, Square from, Square to, move::Move countermove);
+        move::Move get_countermove(Color side, Square from, Square to) const;
+
       private:
         int scale_bonus(int score, int bonus);
         int history[64][64] = {0};
+        move::Move counter_moves[2][64][64] = { move::NO_MOVE };
     };
 }

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -60,6 +60,8 @@ namespace elixir {
                 value = 800000000;
             } else if (move == ss->killers[1]) {
                 value = 700000000;
+            } else if (move == board.history.get_countermove(board.get_side_to_move(), (ss-1)->move.get_from(), (ss-1)->move.get_to())) {
+                value = 600000000;
             } else {
                 // Butterfly History Move Ordering (~45 ELO)
                 value = board.history.get_history(from, to);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -442,6 +442,7 @@ namespace elixir::search {
                                 ss->killers[1] = ss->killers[0];
                                 ss->killers[0] = best_move;
                             }
+                            board.history.update_countermove(board.get_side_to_move(), (ss-1)->move.get_from(), (ss-1)->move.get_to(), move);
                             board.history.update_history(move.get_from(), move.get_to(), depth,
                                                          bad_quiets);
                         }


### PR DESCRIPTION
Similarly to killer moves, the counter move list stores a move that caused a beta cutoff for each `stm-from-to` combination.
During move ordering, given the last played move, this counter move can then be retreived and used for better move ordering.

Passed STC:
```
Elo   | 12.65 +- 7.18 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4864 W: 1404 L: 1227 D: 2233
Penta | [138, 547, 937, 620, 190]
https://chess.aronpetkovski.com/test/638/
```

Bench: 684428