### PR TITLE
feat: added 1 and 2 ply Continuation History

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ ifeq ($(OS),Windows_NT)
 	SUFFIX = .exe
 endif
 
+ifeq ($(UNAME_S), Darwin)
+	STACK = -Wl,-stack_size,0x1000000
+else ifeq ($(UNAME_S), Linux)
+	STACK = -Wl,-zstack_size=0x1000000
+else ifeq ($(OS), Windows_NT)
+	STACK = -Wl,/STACK:16777216
+endif
+
 EXE_NAME = $(EXE)$(SUFFIX)
 
 all: __compile
@@ -19,16 +27,16 @@ tune: __tune_compile
 texel: __texel_compile __texel_run
 
 __compile:
-	$(CXX) -Ofast -march=native -DNDEBUG -std=c++20 -o $(EXE_NAME) elixir.cpp $(SRC)
+	$(CXX) -Ofast -march=native -DNDEBUG -std=c++20 $(STACK) -o $(EXE_NAME) elixir.cpp $(SRC)
 
 __tune_compile:
-	$(CXX) -Ofast -march=native -DNDEBUG -DUSE_TUNE -std=c++20 -o $(EXE_NAME) elixir.cpp $(SRC)
+	$(CXX) -Ofast -march=native -DNDEBUG -DUSE_TUNE -std=c++20 $(STACK) -o $(EXE_NAME) elixir.cpp $(SRC)
 
 __texel_compile:
-	$(CXX) -Ofast -march=native -DNDEBUG -DTEXEL -std=c++20 -o $(EXE_NAME) elixir.cpp $(SRC)
+	$(CXX) -Ofast -march=native -DNDEBUG -DTEXEL -std=c++20 $(STACK) -o $(EXE_NAME) elixir.cpp $(SRC)
 
 __debug_compile:
-	$(CXX) -Og -g -std=c++20 -o $(EXE_NAME) elixir.cpp $(SRC)
+	$(CXX) -Og -g -std=c++20 $(STACK) -o $(EXE_NAME) elixir.cpp $(SRC)
 
 __run:
 	./$(EXE_NAME)

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -4,6 +4,7 @@
 #include "defs.h"
 #include "move.h"
 #include "types.h"
+#include "ss.h"
 
 namespace elixir {
     int HISTORY_GRAVITY = 8289;
@@ -43,7 +44,7 @@ namespace elixir {
         }
     }
 
-    int History::get_history(Square from, Square to) const {
+    int History::get_quiet_history(Square from, Square to) const {
         return history[static_cast<int>(from)][static_cast<int>(to)];
     }
 
@@ -55,5 +56,26 @@ namespace elixir {
     move::Move History::get_countermove(Color side, Square from, Square to) const {
         return counter_moves[static_cast<int>(side)][static_cast<int>(from)][static_cast<int>(to)];
     }
+    
+    void History::update_chs(move::Move& move, search::SearchStack *ss, MoveList &bad_quiets, int depth) {
+        update_single_chs(move, ss - 1, depth, false);
+        update_single_chs(move, ss - 2, depth, false);
 
+        for (auto& bad_quiet : bad_quiets) {
+            update_single_chs(bad_quiet, ss - 1, depth, true);
+            update_single_chs(bad_quiet, ss - 2, depth, true);
+        }
+    }
+
+    int History::get_chs(move::Move& move, const search::SearchStack *ss) const {
+        if (ss->move == move::NO_MOVE || ss->cont_hist == nullptr) return 0;
+        return (*(ss)->cont_hist)[static_cast<int>(move.get_piece())][static_cast<int>(move.get_to())];
+    }
+
+    void History::update_single_chs(move::Move& move, search::SearchStack *ss, int depth, bool is_bad_quiet) {
+        if (ss->move == move::NO_MOVE || ss->cont_hist == nullptr) return;
+        int &score = (*(ss)->cont_hist)[static_cast<int>(move.get_piece())][static_cast<int>(move.get_to())];
+        int bonus = scale_bonus(score, depth * depth) * (is_bad_quiet ? -1 : 1);
+        score += scale_bonus(score, bonus);
+    }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -3,6 +3,7 @@
 #include "defs.h"
 #include "move.h"
 #include "types.h"
+#include "ss.h"
 
 namespace elixir {
     extern int HISTORY_GRAVITY;
@@ -13,10 +14,24 @@ namespace elixir {
 
         void clear();
         void update_history(Square from, Square to, int depth, MoveList &bad_quiets);
-        int get_history(Square from, Square to) const;
+        int get_quiet_history(Square from, Square to) const;
 
         void update_countermove(Color side, Square from, Square to, move::Move countermove);
         move::Move get_countermove(Color side, Square from, Square to) const;
+
+        ContHistEntry *get_cont_hist_entry(move::Move& move) {
+            return &cont_hist[static_cast<int>(move.get_piece())][static_cast<int>(move.get_to())];
+        }
+
+        void update_chs(move::Move& move, search::SearchStack *ss, MoveList &bad_quiets, int depth);
+        int get_chs(move::Move& move, const search::SearchStack *ss) const;
+
+        int get_history(move::Move& move, const search::SearchStack *ss) const {
+          return get_quiet_history(move.get_from(), move.get_to()) +
+                 2 * (get_chs(move, ss - 1) + get_chs(move, ss - 2));
+        }
+
+        ContHistArray cont_hist = {0};
 
       private:
         int history_bonus(int depth) {
@@ -25,5 +40,7 @@ namespace elixir {
         int scale_bonus(int score, int bonus);
         int history[64][64]                 = {0};
         move::Move counter_moves[2][64][64] = {move::NO_MOVE};
+
+        void update_single_chs(move::Move& move, search::SearchStack *ss, int depth, bool is_bad_quiet);
     };
 }

--- a/src/history.h
+++ b/src/history.h
@@ -27,8 +27,7 @@ namespace elixir {
         int get_chs(move::Move& move, const search::SearchStack *ss) const;
 
         int get_history(move::Move& move, const search::SearchStack *ss) const {
-          return get_quiet_history(move.get_from(), move.get_to()) +
-                 2 * (get_chs(move, ss - 1) + get_chs(move, ss - 2));
+          return 2 * get_quiet_history(move.get_from(), move.get_to()) + (get_chs(move, ss - 1) + get_chs(move, ss - 2));
         }
 
         ContHistArray cont_hist = {0};

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -6,6 +6,7 @@
 #include "movegen.h"
 #include "movepicker.h"
 #include "search.h"
+#include "ss.h"
 
 namespace elixir {
 
@@ -66,7 +67,7 @@ namespace elixir {
                 value = 600000000;
             } else {
                 // Butterfly History Move Ordering (~45 ELO)
-                value = board.history.get_history(from, to);
+                value = board.history.get_history(move, ss);
             }
 
             scores[i] = value;

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -3,6 +3,7 @@
 #include "move.h"
 #include "movegen.h"
 #include "search.h"
+#include "ss.h"
 #include "utils/static_vector.h"
 
 namespace elixir {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "search.h"
+#include "ss.h"
 
 #include "board/board.h"
 #include "evaluate.h"
@@ -320,6 +321,7 @@ namespace elixir::search {
                 | multiple null move searching in a row.                       |
                 */
                 ss->move = move::NO_MOVE;
+                ss->cont_hist = nullptr;
 
                 board.make_null_move();
                 int score = -negamax(board, -beta, -beta + 1, depth - R, info, local_pv, ss + 1);
@@ -402,6 +404,7 @@ namespace elixir::search {
             | Add the current move to search stack. |
             */
             ss->move = move;
+            ss->cont_hist = board.history.get_cont_hist_entry(move);
 
             legals++;
             info.nodes++;
@@ -457,6 +460,7 @@ namespace elixir::search {
                                                              (ss - 1)->move.get_to(), move);
                             board.history.update_history(move.get_from(), move.get_to(), depth,
                                                          bad_quiets);
+                            board.history.update_chs(move, ss, bad_quiets, depth);
                         }
                         flag = TT_BETA;
                         break;

--- a/src/search.h
+++ b/src/search.h
@@ -8,13 +8,6 @@
 #include "move.h"
 
 namespace elixir::search {
-    struct SearchStack {
-        move::Move move       = move::NO_MOVE;
-        move::Move killers[2] = {};
-        int eval = -INF;
-        int ply;
-    };
-
     class SearchInfo {
       public:
         SearchInfo() = default;

--- a/src/ss.h
+++ b/src/ss.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "defs.h"
+#include "types.h"
+#include "move.h"
+
+namespace elixir::search {
+    struct SearchStack {
+        move::Move move       = move::NO_MOVE;
+        move::Move killers[2] = {};
+        int eval = -INF;
+        int ply;
+        ContHistEntry* cont_hist = nullptr;
+    };
+}

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 namespace elixir {
@@ -23,4 +24,7 @@ namespace elixir {
     using EvalScore = std::int32_t;
     using Score     = std::int16_t;
     using PhaseType = std::uint8_t;
+
+    using ContHistEntry = std::array<std::array<int, 64>, 12>;
+    using ContHistArray = std::array<std::array<ContHistEntry, 64>, 12>;
 }


### PR DESCRIPTION
```
Elo   | 4.80 +- 3.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15636 W: 3860 L: 3644 D: 8132
Penta | [390, 1832, 3225, 1914, 457]
https://chess.aronpetkovski.com/test/1464/
```
Bench: 530699
