### PR TITLE
feat: added material scaling of evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -26,6 +26,9 @@ namespace elixir::eval {
     int piece_values[7] = {MP_PAWN, MP_KNIGHT, MP_BISHOP, MP_ROOK, MP_QUEEN, MP_KING, 0};
 
     int evaluate(const Board &board) {
-        return nn.eval(board.get_side_to_move());
+        const int eval =  nn.eval(board.get_side_to_move());
+        const int phase = 3 * count_bits(board.knights()) + 3 * count_bits(board.bishops()) + 5 * count_bits(board.rooks()) + 10 * count_bits(board.queens());
+        const int scaled_eval = eval * (phase + 206) / 256;
+        return scaled_eval;
     }
 }


### PR DESCRIPTION
```
Elo   | 2.37 +- 1.81 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 39854 W: 6228 L: 5956 D: 27670
Penta | [386, 3904, 11080, 4166, 391]
https://chess.aronpetkovski.com/test/2041/
```

Bench: 384294