### PR TITLE
build: added link time optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ AVX2FLAGS    = -DUSE_AVX2 -DUSE_SIMD -mavx2 -mbmi
 BMI2FLAGS    = -DUSE_AVX2 -DUSE_SIMD -mavx2 -mbmi -mbmi2
 AVX512FLAGS  = -DUSE_AVX512 -DUSE_SIMD -mavx512f -mavx512bw
 
+CXXFLAGS = -flto=auto
+
 ARCH_DETECTED =
 PROPERTIES = $(shell echo | $(CXX) -march=native -E -dM -)
 ifneq ($(findstring __AVX512F__, $(PROPERTIES)),)
@@ -53,7 +55,6 @@ endif
 ifeq ($(ARCH_DETECTED), AVX2)
 	CXXFLAGS += $(AVX2FLAGS)
 endif
-
 
 all: __compile
 


### PR DESCRIPTION
```
Elo   | 8.07 +- 3.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7406 W: 978 L: 806 D: 5622
Penta | [26, 590, 2330, 700, 57]
https://chess.aronpetkovski.com/test/2455/
```

Bench: 378333