### PR TITLE
feat: added double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -388,7 +388,8 @@ namespace elixir::search {
                 ss->excluded_move = move::NO_MOVE;
 
                 if (s_score < s_beta) {
-                    extensions++;
+                    const int double_margin = 300 * pv_node;
+                    extensions += 1 + (s_score < s_beta - double_margin);
                 }
 
                 else if (s_beta >= beta) 


### PR DESCRIPTION
```
Elo   | 1.89 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47498 W: 6133 L: 5875 D: 35490
Penta | [285, 4134, 14654, 4390, 286]
https://chess.aronpetkovski.com/test/2411/
```

Bench: 378334