### PR TITLE
feat: added ttpv reduction to lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -236,6 +236,8 @@ namespace elixir::search {
             tt_move = result.best_move;
         }
 
+        const bool tt_pv = (tt_hit && result.tt_pv) || pv_node;
+
         /*
         | Internal Iterative Reduction (~6 ELO) : If no TT move is found for this position, |
         | searching this node will likely take a lot of time, and this node is likely to be |
@@ -427,6 +429,7 @@ namespace elixir::search {
             R -= (is_quiet_move ? history_score / HISTORY_GRAVITY : 0);
             R -= board.is_in_check();
             R += cutnode;
+            R -= tt_pv;
             
             if (depth > 1 && legals > 1) {
                 R = std::clamp(R, 1, new_depth);
@@ -489,7 +492,7 @@ namespace elixir::search {
         }
 
         if (!ss->excluded_move) {
-            tt->store_tt(board.get_hash_key(), best_score, best_move, depth, ss->ply, flag, pv);
+            tt->store_tt(board.get_hash_key(), best_score, best_move, depth, ss->ply, flag, pv, tt_pv);
         }
 
         return best_score;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -41,13 +41,14 @@ namespace elixir {
             result.score     = entry.score;
             result.depth     = entry.depth;
             flag             = entry.flag;
+            result.tt_pv     = entry.tt_pv;
             return true;
         }
         return false;
     }
 
     void TranspositionTable::store_tt(U64 key, int score, move::Move move, U8 depth, int ply,
-                                      TTFlag flag, search::PVariation pv) {
+                                      TTFlag flag, search::PVariation pv, bool tt_pv) {
         U32 index     = get_index(key);
         TTEntry entry = table[index];
 
@@ -69,6 +70,7 @@ namespace elixir {
         entry.move  = move;
         entry.depth = depth;
         entry.flag  = flag;
+        entry.tt_pv = tt_pv;
 
         table[index] = entry;
     }

--- a/src/tt.h
+++ b/src/tt.h
@@ -16,7 +16,8 @@ namespace elixir {
         I16 score       = 0;
         move::Move move = move::NO_MOVE;
         I8 depth        = -1;
-        TTFlag flag     = TT_NONE;
+        TTFlag flag : 6     = TT_NONE;
+        bool tt_pv: 2       = false;
 
         bool operator==(const TTEntry &other) const {
             return key == other.key && score == other.score && depth == other.depth &&
@@ -29,9 +30,10 @@ namespace elixir {
         int score;
         move::Move best_move;
         U8 depth;
-        TTFlag flag;
+        TTFlag flag: 6;
+        bool tt_pv: 2;
 
-        ProbedEntry() : score(0), best_move(move::NO_MOVE), depth(0), flag(TT_NONE) {}
+        ProbedEntry() : score(0), best_move(move::NO_MOVE), depth(0), flag(TT_NONE), tt_pv(false) {}
 
         ProbedEntry operator=(const TTEntry &entry) {
             score     = entry.score;
@@ -49,7 +51,7 @@ namespace elixir {
         void clear_tt();
         void resize(U16 size);
         void store_tt(U64 key, int score, move::Move move, U8 depth, int ply, TTFlag flag,
-                      search::PVariation pv);
+                      search::PVariation pv, bool tt_pv = false);
         bool probe_tt(ProbedEntry &result, U64 key, U8 depth, int alpha, int beta, TTFlag &flag);
         U32 get_hashfull() {
             return static_cast<U32>(static_cast<F64>(entries) / static_cast<F64>(table.capacity()) *


### PR DESCRIPTION
```
Elo   | 2.00 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 51254 W: 8040 L: 7745 D: 35469
Penta | [490, 5100, 14135, 5429, 473]
https://chess.aronpetkovski.com/test/2799/
```
Bench: 4898086