### PR TITLE
feat: changed nmp reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -291,7 +291,7 @@ namespace elixir::search {
             | opponent an extra move to see if we are still better.                 |
             */
             if (depth >= NMP_DEPTH && (ss - 1)->move && eval >= beta) {
-                int R = NMP_BASE_REDUCTION + depth / NMP_DIVISOR;
+                int R = NMP_BASE_REDUCTION + depth / NMP_DIVISOR + std::min((eval - beta) / 200, 6);
                 R     = std::min(R, depth);
 
                 /*


### PR DESCRIPTION
```
Elo   | 1.76 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63646 W: 9821 L: 9498 D: 44327
Penta | [574, 6328, 17716, 6611, 594]
https://chess.aronpetkovski.com/test/2781/
```
Bench: 4398444