### PR TITLE
feat: use improving heuristic in tt replacement policy

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -492,7 +492,7 @@ namespace elixir::search {
         }
 
         if (!ss->excluded_move) {
-            tt->store_tt(board.get_hash_key(), best_score, best_move, depth, ss->ply, flag, pv, tt_pv);
+            tt->store_tt(board.get_hash_key(), best_score, best_move, depth, ss->ply, flag, pv, tt_pv, improving);
         }
 
         return best_score;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -48,11 +48,11 @@ namespace elixir {
     }
 
     void TranspositionTable::store_tt(U64 key, int score, move::Move move, U8 depth, int ply,
-                                      TTFlag flag, search::PVariation pv, bool tt_pv) {
+                                      TTFlag flag, search::PVariation pv, bool tt_pv, bool improving) {
         U32 index     = get_index(key);
         TTEntry entry = table[index];
 
-        bool replace = entry.key != key || entry.depth < depth + 2 || flag == TT_EXACT;
+        bool replace = entry.key != key || entry.depth < depth + 2 || flag == TT_EXACT || improving;
 
         if (! replace)
             return;

--- a/src/tt.h
+++ b/src/tt.h
@@ -51,7 +51,7 @@ namespace elixir {
         void clear_tt();
         void resize(U16 size);
         void store_tt(U64 key, int score, move::Move move, U8 depth, int ply, TTFlag flag,
-                      search::PVariation pv, bool tt_pv = false);
+                      search::PVariation pv, bool tt_pv = false, bool improving = false);
         bool probe_tt(ProbedEntry &result, U64 key, U8 depth, int alpha, int beta, TTFlag &flag);
         U32 get_hashfull() {
             return static_cast<U32>(static_cast<F64>(entries) / static_cast<F64>(table.capacity()) *


### PR DESCRIPTION
```
Elo   | 7.12 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9854 W: 1662 L: 1460 D: 6732
Penta | [93, 909, 2746, 1061, 118]
https://chess.aronpetkovski.com/test/2817/
```
Bench: 4854669