### PR TITLE
feat: use tt score in qs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -108,6 +108,11 @@ namespace elixir::search {
             return result.score;
         }
 
+        if (tt_hit) {
+            best_score = result.score;
+            best_move  = result.best_move;
+        }
+
         if (best_score >= beta) {
             return best_score;
         }


### PR DESCRIPTION
```
Elo   | 3.63 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23558 W: 4131 L: 3885 D: 15542
Penta | [261, 2471, 6114, 2627, 306]
https://chess.aronpetkovski.com/test/2886/
```

Bench: 4819066