### PR TITLE
fix: dont use exact flag in qs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -157,7 +157,7 @@ namespace elixir::search {
                 if (score > alpha) {
                     alpha = score;
                     pv.update(move, score, local_pv);
-                    flag = TT_EXACT;
+                    flag = TT_ALPHA;
                 }
 
                 if (alpha >= beta) {


### PR DESCRIPTION
```
Elo   | 0.01 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 27790 W: 4802 L: 4801 D: 18187
Penta | [321, 3006, 7230, 3027, 311]
https://chess.aronpetkovski.com/test/3055/
```

Bench: 4612610