### PR TITLE
feat: added board phase in nmp reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -274,6 +274,16 @@ namespace elixir::search {
             return true;
         }();
 
+        const bool worsening = [&] {
+            if (in_check)
+                return true;
+            if (ss->ply > 0 && std::abs((ss - 1)->eval) != INF)
+                return ss->eval < (ss - 1)->eval;
+            if (ss->ply > 2 && std::abs((ss - 3)->eval) != INF)
+                return ss->eval < (ss - 3)->eval;
+            return false;
+        }();
+
         if (! pv_node && ! in_check && !ss->excluded_move) {
             /*
             | Razoring (~4 ELO) : If out position is way below alpha, do a verification |
@@ -298,7 +308,7 @@ namespace elixir::search {
             | opponent an extra move to see if we are still better.                 |
             */
             if (depth >= NMP_DEPTH && (ss - 1)->move && eval >= beta && board.has_non_pawn_material()) {
-                int R = NMP_BASE_REDUCTION + depth / NMP_DIVISOR + std::min((eval - beta) / 200, 6);
+                int R = NMP_BASE_REDUCTION + depth / NMP_DIVISOR + std::min((eval - beta) / 200, 6) + std::min(board.get_phase(), 24) / 8;
                 R     = std::min(R, depth);
 
                 /*


### PR DESCRIPTION
```
Elo   | 4.17 +- 2.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18658 W: 3110 L: 2886 D: 12662
Penta | [183, 1862, 5005, 2106, 173]
https://chess.aronpetkovski.com/test/3273/
```

Bench: 4772842