### PR TITLE
fix: fixed search stack eval

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -148,9 +148,9 @@ namespace elixir {
     constexpr int DEFAULT_HASH_SIZE = 64;
     constexpr int MAX_HASH          = 1024;
 
-    constexpr int MIN_THREADS = 1;
+    constexpr int MIN_THREADS     = 1;
     constexpr int DEFAULT_THREADS = 1;
-    constexpr int MAX_THREADS = 1024;
+    constexpr int MAX_THREADS     = 1024;
 
     static inline int get_rank(Square sq) {
         return (static_cast<int>(sq) >> 3) & 7;
@@ -165,6 +165,7 @@ namespace elixir {
     }
 
     constexpr I32 INF        = 32001;
+    constexpr I32 SCORE_NONE = 32001;
     constexpr I32 MATE       = 32000;
     constexpr I32 MATE_FOUND = MATE - MAX_PLY;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -258,7 +258,7 @@ namespace elixir::search {
 
         if (!ss->excluded_move) {
             if (in_check)
-                eval = ss->eval = INF;
+                eval = ss->eval = SCORE_NONE;
 
             else
                 eval = ss->eval = (tt_hit) ? result.score : board.evaluate();
@@ -267,9 +267,9 @@ namespace elixir::search {
         const bool improving = [&] {
             if (in_check)
                 return false;
-            if (ss->ply > 1 && (ss - 2)->eval != -INF)
+            if ((ss - 2)->eval != SCORE_NONE)
                 return ss->eval > (ss - 2)->eval;
-            if (ss->ply > 3 && (ss - 4)->eval != -INF)
+            if ((ss - 4)->eval != SCORE_NONE)
                 return ss->eval > (ss - 4)->eval;
             return true;
         }();
@@ -277,9 +277,9 @@ namespace elixir::search {
         const bool worsening = [&] {
             if (in_check)
                 return true;
-            if (ss->ply > 0 && std::abs((ss - 1)->eval) != INF)
+            if ((ss - 1)->eval != SCORE_NONE)
                 return ss->eval < (ss - 1)->eval;
-            if (ss->ply > 2 && std::abs((ss - 3)->eval) != INF)
+            if ((ss - 3)->eval != SCORE_NONE)
                 return ss->eval < (ss - 3)->eval;
             return false;
         }();
@@ -609,7 +609,7 @@ namespace elixir::search {
                 (ss + i)->move       = move::NO_MOVE;
                 (ss + i)->killers[0] = move::NO_MOVE;
                 (ss + i)->killers[1] = move::NO_MOVE;
-                (ss + i)->eval       = INF;
+                (ss + i)->eval       = SCORE_NONE;
             }
 
             for (int i = 0; i < MAX_DEPTH; i++) {

--- a/src/ss.h
+++ b/src/ss.h
@@ -10,7 +10,7 @@ namespace elixir::search {
         move::Move move          = move::NO_MOVE;
         move::Move excluded_move = move::NO_MOVE;
         move::Move killers[2]    = {};
-        int eval                 = -INF;
+        int eval                 = SCORE_NONE;
         ContHistEntry *cont_hist = nullptr;
         int ply;
     };


### PR DESCRIPTION
```
Elo   | 1.56 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 13148 W: 2211 L: 2152 D: 8785
Penta | [134, 1394, 3484, 1403, 159]
https://chess.aronpetkovski.com/test/3503/
```
Bench: 4950344