### PR TITLE
fix: use tt score only when it is valid in qs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -108,7 +108,7 @@ namespace elixir::search {
             return result.score;
         }
 
-        if (tt_hit) {
+        if (tt_hit && can_cutoff) {
             best_score = result.score;
             best_move  = result.best_move;
         }


### PR DESCRIPTION
```
Elo   | 4.05 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.04 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7900 W: 2131 L: 2039 D: 3730
Penta | [103, 933, 1793, 1011, 110]
https://chess.aronpetkovski.com/test/3586/
```

Bench: 5738653