### PR TITLE
feat: updated nmp guard

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -304,6 +304,7 @@ namespace elixir::search {
             | opponent an extra move to see if we are still better.                 |
             */
             if (depth >= NMP_DEPTH && (ss - 1)->move && ss->eval >= beta &&
+                ss->static_eval >= beta + 170 - 24 * depth &&
                 board.has_non_pawn_material()) {
                 int R = NMP_BASE_REDUCTION + depth / NMP_DIVISOR +
                         std::min<double>((ss->eval - beta) / NMP_EVAL_BASE, (NMP_EVAL_MAX / 10.0)) +


### PR DESCRIPTION
```
Elo   | 2.64 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32686 W: 6504 L: 6256 D: 19926
Penta | [146, 3679, 8468, 3881, 169]
https://chess.aronpetkovski.com/test/4325/
```
Bench: 5590737