### PR TITLE
feat: added correction history

### DIFF
--- a/src/search/history/correction_history.h
+++ b/src/search/history/correction_history.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "move.h"
+#include "types.h"
+
+namespace elixir {
+    const int correction_history_size = 16384;
+    const int correction_history_limit = 512;
+
+    using CorrectionHistoryTable = std::vector<std::array<int, correction_history_size>>;
+
+    class CorrectionHistory {
+      public:
+        CorrectionHistory() {
+            corr_hist.resize(2);
+            clear();
+        }
+        ~CorrectionHistory() = default;
+
+        void clear();
+
+        int correct_static_eval(int static_eval, Color side, U64 pawn_hash_key) const;
+        void update_correction_history(int bonus, Color side, U64 pawn_hash_key);
+      private:
+        CorrectionHistoryTable corr_hist;
+    };
+}

--- a/src/search/history/history.cpp
+++ b/src/search/history/history.cpp
@@ -110,4 +110,23 @@ namespace elixir {
         int bonus = (is_bad_quiet) ? history_malus(depth) : history_bonus(depth);
         score += scale_bonus(score, bonus);
     }
+
+    void CorrectionHistory::clear() {
+        for (auto &entry : corr_hist) {
+            for (auto &piece : entry) {
+                piece = 0;
+            }
+        }
+    }
+
+    int CorrectionHistory::correct_static_eval(int static_eval, Color side, U64 pawn_hash_key) const {
+        const int correction_score = corr_hist[static_cast<int>(side)][pawn_hash_key & (correction_history_size - 1)];
+        const int adjusted_score = static_eval + (correction_score * std::abs(correction_score)) / 1024;
+        return std::clamp(adjusted_score, -MATE_FOUND + 1, MATE_FOUND - 1);
+    }
+
+    void CorrectionHistory::update_correction_history(int bonus, Color side, U64 pawn_hash_key) {
+        int &score = corr_hist[static_cast<int>(side)][pawn_hash_key & (correction_history_size - 1)];
+        score += scale_bonus(score, bonus, correction_history_limit);
+    }
 }

--- a/src/search/history/history.h
+++ b/src/search/history/history.h
@@ -7,6 +7,7 @@
 
 #include "continuation_history.h"
 #include "countermove_history.h"
+#include "correction_history.h"
 #include "history_formulas.h"
 #include "quiet_history.h"
 
@@ -28,5 +29,6 @@ namespace elixir {
         QuietHistory quiet_history;
         ContiuationHistory continuation_history;
         CounterMoveHistory countermove_history;
+        CorrectionHistory correction_history;
     };
 }

--- a/src/search/history/history_formulas.h
+++ b/src/search/history/history_formulas.h
@@ -22,7 +22,7 @@ namespace elixir {
                          HISTORY_MALUS_MAX);
     }
 
-    inline int scale_bonus(int score, int bonus) {
-        return bonus - score * std::abs(bonus) / HISTORY_GRAVITY;
+    inline int scale_bonus(int score, int bonus, int gravity = HISTORY_GRAVITY) {
+        return bonus - score * std::abs(bonus) / gravity;
     }
 }

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -80,6 +80,7 @@ namespace elixir::search {
         int eval            = (tt_hit) ? result.static_eval : board.evaluate();
         I16 raw_static_eval = eval;
 
+        eval = history.correction_history.correct_static_eval(eval, board.get_side_to_move(), board.get_pawn_hash());
         /*
         | If TT score is found and it is usable, then cutoff. |
         */
@@ -251,8 +252,11 @@ namespace elixir::search {
         | Otherwise, if we have a TT hit, we use the stored score. If not, we evaluate the position.
         |
         */
+        I16 raw_static_eval;
         if (! ss->excluded_move) {
             ss->static_eval = (tt_hit) ? result.static_eval : board.evaluate();
+            raw_static_eval = ss->static_eval;
+            ss->static_eval = history.correction_history.correct_static_eval(ss->static_eval, board.get_side_to_move(), board.get_pawn_hash());
             if (in_check)
                 ss->eval = SCORE_NONE;
 
@@ -261,7 +265,6 @@ namespace elixir::search {
             }
         }
 
-        I16 raw_static_eval = ss->static_eval;
 
         /*
         | Improving Heuristic (~10 ELO) : Check if our position is better than it was 2 or 4 plies
@@ -544,6 +547,11 @@ namespace elixir::search {
         if (! ss->excluded_move) {
             tt->store_tt(board.get_hash_key(), best_score, raw_static_eval, best_move, depth,
                          ss->ply, flag, pv, tt_pv, improving);
+            
+            if (!in_check && (!best_move || !best_move.is_capture()) && !(best_score >= beta && best_score <= ss->static_eval) && !(!best_move && best_score >= ss->static_eval)) {
+                const int bonus = std::clamp((best_score - ss->static_eval) * depth / 8, -correction_history_limit / 4, correction_history_limit / 4);
+                history.correction_history.update_correction_history(bonus, board.get_side_to_move(), board.get_pawn_hash());
+            }
         }
 
         return best_score;


### PR DESCRIPTION
```
Elo   | 5.03 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14018 W: 2849 L: 2646 D: 8523
Penta | [54, 1518, 3675, 1695, 67]
https://chess.aronpetkovski.com/test/4544/
```
Bench: 3619001