### PR TITLE
feat: reduce capture moves less in LMR

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -494,6 +494,7 @@ namespace elixir::search {
             R += cutnode;
             R -= tt_pv;
             R += ! improving;
+            R -= !is_quiet_move;
 
             if (depth > 1 && legals > 1) {
                 R             = std::clamp(R, 1, new_depth);


### PR DESCRIPTION
```
Elo   | 3.66 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21342 W: 4522 L: 4297 D: 12523
Penta | [104, 2405, 5449, 2588, 125]
https://chess.aronpetkovski.com/test/5879/
```

Bench: 3698290